### PR TITLE
Add CurrentVoiceRoom to TAGame.PRI_TA

### DIFF
--- a/CPPRP/data/GameClasses.h
+++ b/CPPRP/data/GameClasses.h
@@ -264,6 +264,7 @@ namespace CPPRP
 
 			//Unused
 			ActiveActor ReplacingBotPRI;
+			std::string CurrentVoiceRoom;
 			//PlayerReplicatedEventInfo_TA               PREI
 		};
 

--- a/CPPRP/generated/GameClassMacros.h
+++ b/CPPRP/generated/GameClassMacros.h
@@ -168,6 +168,7 @@ GAMEFIELD(TAGame, PRI_TA, SecondaryTitle, struct ReplicatedTitle);
 GAMEFIELD(TAGame, PRI_TA, PlayerHistoryKey, struct HistoryKey);
 GAMEFIELD(TAGame, PRI_TA, bIsDistracted, bool);
 GAMEFIELD(TAGame, PRI_TA, ReplacingBotPRI, ActiveActor);
+GAMEFIELD(TAGame, PRI_TA, CurrentVoiceRoom, std::string);
 GAMECLASS(TAGame, PRI_KnockOut_TA);
 GAMEFIELD(TAGame, PRI_KnockOut_TA, Knockouts, int);
 GAMEFIELD(TAGame, PRI_KnockOut_TA, KnockoutDeaths, int);


### PR DESCRIPTION
The recent voice update broke parsing due to the missing CurrentVoiceRoom PRI_TA field.