### PR TITLE
Bump std standard to C++20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ else
 endif
 BUILDFLAGS := -DDEBUG=$(DEBUG) -DRELEASE=$(RELEASE)
 CXX ?= g++-9
-CXXFLAGS ?= -fPIC -std=c++17 -static-libstdc++ $(INC_FLAGS) -w  -Wfatal-errors -DCPPRP_PRETTYSUPPORT -lstdc++fs #-DPARSE_UNSAFE 
+CXXFLAGS ?= -fPIC -std=c++20 -static-libstdc++ $(INC_FLAGS) -w  -Wfatal-errors -DCPPRP_PRETTYSUPPORT -lstdc++fs #-DPARSE_UNSAFE
 LDFLAGS ?= ${LIB_FLAGS}
 ifeq ($(RELEASE),0)
 	CXXFLAGS += -O0 -ggdb


### PR DESCRIPTION
The default `make all` sets the debug flag which will cause compilation of `std::format` -- a function not added until c++20 -- to fail.

https://github.com/Bakkes/CPPRP/blob/4e743d69442d1f28e1ee4e1184e2651b504501f3/CPPRP/ReplayFile.cpp#L566

https://en.cppreference.com/w/cpp/utility/format/format